### PR TITLE
Clone of #20 - Fixes an issue with BG matching text color in drop-downs

### DIFF
--- a/css/eclipsephase.css
+++ b/css/eclipsephase.css
@@ -17,6 +17,7 @@
   --focusBackground: #2b2b2b;
   --highlightBackground: #414141;
   --accentBackground: #24485d;
+  --color-bg-option: #1f1f1f;
 }
 
 .grid,


### PR DESCRIPTION
After the last Foundry update (can't provide number due to Foundry's V9 version labeling) text color in the module matches the background color of drop-down menus. Issue wasn't present when reverting to Foundry 0.8.9, but persisted with a fresh, up to date install of Foundry and the module.
Added the new default element 'color-bg-option' to eclipsephase.css and specified the same color as used in 'mainBackground', which renders the text readable. Screenshots available at #20.