### PR TITLE
Fix weapon type detection

### DIFF
--- a/module/actor/EPactorSheet.js
+++ b/module/actor/EPactorSheet.js
@@ -1042,7 +1042,7 @@ export default class EPactorSheet extends ActorSheet {
       let weapon = this.actor.items.get(weaponID)
       let selectedWeaponMode = ""
       weaponName = weapon.name;
-      weaponType = dataset.rolledFrom === "ccWeapon" ? "melee" : "ranged";
+      weaponType = dataset.rolledfrom === "ccWeapon" ? "melee" : "ranged";
       currentAmmo = weapon.system.ammoMin;
       maxAmmo = weapon.system.ammoMax;
 

--- a/module/actor/EPnpcSheet.js
+++ b/module/actor/EPnpcSheet.js
@@ -501,7 +501,7 @@ export default class EPnpcSheet extends ActorSheet {
           let weapon = this.actor.items.get(weaponID)
           let selectedWeaponMode = ""
           weaponName = weapon.name;
-          weaponType = dataset.rolledFrom === "ccWeapon" ? "melee" : "ranged";
+          weaponType = dataset.rolledfrom === "ccWeapon" ? "melee" : "ranged";
           currentAmmo = weapon.system.ammoMin;
           maxAmmo = weapon.system.ammoMax;
     


### PR DESCRIPTION
Due to a capitalization issue, all weapon rolls from the character sheets are considered `ranged`; This causes `meleeDamageMod` to not be added to melee damage rolls, and probably a host of other quirky issues as well.